### PR TITLE
Remove requests as a requirement, use django.test.Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following instructions are for an installation on a djangocms-based website 
 
 # Prerequisites
 
-This application need `beautifulsoup4` (>=4.7.0), `requests`, `djangocms` & `djangocms_page_meta` *(==0.8.5 if using django < 1.11)*.
+This application need `beautifulsoup4` (>=4.7.0), `djangocms` & `djangocms_page_meta` *(==0.8.5 if using django < 1.11)*.
 
 ----
 
@@ -113,62 +113,6 @@ DJANGO_CHECK_SEO_EXCLUDE_CONTENT = "tag, .class, #id, tag > .child_class"
 ### *Example:*
 
 See [this issue comment](https://github.com/kapt-labs/django-check-seo/issues/35#issuecomment-593429870) for an example.
-
-----
-
-## Use `http` instead of `https`
-
-By default, the application will attempt to make requests in https.
-
-To enable plain http queries, you can add a variable named `DJANGO_CHECK_SEO_FORCE_HTTP` set to `True` in your settings.py.
-
-### *Example:*
-
-```python
-# Force HTTP
-DJANGO_CHECK_SEO_FORCE_HTTP = True
-
-# Force HTTPS (default case, same as not defining the variable)
-DJANGO_CHECK_SEO_FORCE_HTTP = False
-```
-
-----
-
-## Authentication
-
-The website you want to test may require a prior connection due to a .htaccess file (or may use [wsgi-basic-auth](https://github.com/mvantellingen/wsgi-basic-auth)), which prevents django-check-seo from accessing its html code.
-
-To prevent this, you can specify the login informations (username/password) in the `DJANGO_CHECK_SEO_AUTH` dictionnary (in your website settings).
-
-This dictionary must contain two keys named `user` and `pass`.
-
-### *Example:*
-
- * In `mywebsite/settings.py`:
- ```python
- DJANGO_CHECK_SEO_AUTH = {
-     "user": os.getenv("HTACCESS_USER"),
-     "pass": os.getenv("HTACCESS_PASS"),
- }
- ```
-
- * In `.env` file:
- ```
- export HTACCESS_USER=myusername
- export HTACCESS_PASS=mypassword
-
- WSGI_AUTH_CREDENTIALS=$HTACCESS_USER:$HTACCESS_PASS
- ```
-
-### Authentication and redirections
-
-When you _really_ want django-check-seo to follow a redirection and you _really_ want to authenticate on the redirected site using the `DJANGO_CHECK_SEO_AUTH` credentials, you can set this config var to `True` in your site settings:
-
-```
-DJANGO_CHECK_SEO_AUTH_FOLLOW_REDIRECTS = True
-```
-
-***Warning!** This could be considered a bad practice to allow this by default, because if you create a redirection on your (authenticated-only accessible) website, then the destination website will have access to the credentials by reading the `Authorization` header (see [CVE-2014-1829](https://nvd.nist.gov/vuln/detail/CVE-2014-1829)). See [this issue](https://github.com/kapt-labs/django-check-seo/issues/43#issue-839650874) for a valid usecase.*
 
 ----
 

--- a/django_check_seo/conf/settings.py
+++ b/django_check_seo/conf/settings.py
@@ -15,26 +15,6 @@ DJANGO_CHECK_SEO_SETTINGS = {
 # update settings redefined in projectname/settings.py
 DJANGO_CHECK_SEO_SETTINGS.update(getattr(settings, "DJANGO_CHECK_SEO_SETTINGS", {}))
 
-
-# define auth data (for .htaccess files)
-DJANGO_CHECK_SEO_AUTH = {}
-# update auth data with values from projectname/settings.py
-DJANGO_CHECK_SEO_AUTH.update(getattr(settings, "DJANGO_CHECK_SEO_AUTH", {}))
-
-
-# see https://github.com/kapt-labs/django-check-seo/issues/43 for more informations
-DJANGO_CHECK_SEO_AUTH_FOLLOW_REDIRECTS = False
-# update redirect with authentication strategy with value from projectname/settings.py
-DJANGO_CHECK_SEO_AUTH_FOLLOW_REDIRECTS = getattr(
-    settings, "DJANGO_CHECK_SEO_AUTH_FOLLOW_REDIRECTS", False
-)
-
-# define http(s) settings (default = use https)
-DJANGO_CHECK_SEO_FORCE_HTTP = False
-# update http(s) settings with value from projectname/settings.py
-DJANGO_CHECK_SEO_FORCE_HTTP = getattr(settings, "DJANGO_CHECK_SEO_FORCE_HTTP", False)
-
-
 # define css selector to search content into (used for retrieving main content of the page)
 DJANGO_CHECK_SEO_SEARCH_IN = {
     "type": "exclude",

--- a/django_check_seo/views.py
+++ b/django_check_seo/views.py
@@ -1,8 +1,7 @@
 import json
 
-import requests
 from bs4 import BeautifulSoup
-from django.contrib.sites.models import Site
+from django.test import Client
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
 from django.views import generic
@@ -20,56 +19,14 @@ class IndexView(generic.base.TemplateView):
             *args, **kwargs
         )
 
-        if settings.DJANGO_CHECK_SEO_FORCE_HTTP:
-            protocol = "http://"
-        else:
-            protocol = "https://"
+        client = Client()
+        page = self.request.GET.get("page")
+        response = client.get(page)
 
-        # get content of the page
-        if "http" not in self.request.GET.get(
-            "page", None
-        ):  # url like "/fr/article-du-site/"
-            full_url = (
-                protocol
-                + Site.objects.get_current().domain
-                + self.request.GET.get("page", None)
-            )
-        else:  # url like "http://mydomain.ext/en/my-page-name/"
-            full_url = self.request.GET.get("page", None)
-
-        # use credentials if provided (pass through .htaccess auth)
-        if (
-            settings.DJANGO_CHECK_SEO_AUTH
-            and settings.DJANGO_CHECK_SEO_AUTH["user"] is not None
-            and settings.DJANGO_CHECK_SEO_AUTH["pass"] is not None
-        ):
-            r = requests.get(
-                full_url,
-                auth=(
-                    settings.DJANGO_CHECK_SEO_AUTH["user"],
-                    settings.DJANGO_CHECK_SEO_AUTH["pass"],
-                ),
-                headers={"Cache-Control": "no-store"},
-                allow_redirects=False,
-            )
-            if (
-                300 < r.status_code < 400
-                and settings.DJANGO_CHECK_SEO_AUTH_FOLLOW_REDIRECTS
-            ):
-                r = requests.get(
-                    r.headers["Location"],
-                    auth=(
-                        settings.DJANGO_CHECK_SEO_AUTH["user"],
-                        settings.DJANGO_CHECK_SEO_AUTH["pass"],
-                    ),
-                )
-        else:
-            r = requests.get(full_url, headers={"Cache-Control": "no-store"})
-
-        soup = BeautifulSoup(r.text, features="lxml")
+        soup = BeautifulSoup(response.content, features="lxml")
 
         # populate class with data
-        page_stats = site.Site(soup, full_url)
+        page_stats = site.Site(soup, page)
 
         # magic happens here!
         launch_checks.launch_checks(page_stats)


### PR DESCRIPTION
This removes `requests` as a requirement for this package and utilizes `django.test.Client` instead. 
This also removes the need for Basic Auth support (I guess, otherwise it might be enabled by forcing authentication on the client).

