### PR TITLE
Django 4: ugettext_lazy was removed in favor of gettext_lazy

### DIFF
--- a/django_check_seo/checks_list/check_description.py
+++ b/django_check_seo/checks_list/check_description.py
@@ -207,7 +207,6 @@ def run(site):
         site.warnings.append(too_much_meta)
     # perfect
     elif number_meta_description == 1:
-        # site.problems.append(no_meta_description)
         meta_description_only_one.searched_in = meta_description
         site.success.append(meta_description_only_one)
 

--- a/django_check_seo/checks_list/check_description.py
+++ b/django_check_seo/checks_list/check_description.py
@@ -207,7 +207,7 @@ def run(site):
         site.warnings.append(too_much_meta)
     # perfect
     elif number_meta_description == 1:
-        site.problems.append(no_meta_description)
+        # site.problems.append(no_meta_description)
         meta_description_only_one.searched_in = meta_description
         site.success.append(meta_description_only_one)
 

--- a/django_check_seo/cms_toolbars.py
+++ b/django_check_seo/cms_toolbars.py
@@ -3,7 +3,7 @@
 # Third party
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class DjangoSeoToolbar(CMSToolbar):

--- a/django_check_seo/cms_toolbars.py
+++ b/django_check_seo/cms_toolbars.py
@@ -3,7 +3,11 @@
 # Third party
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
-from django.utils.translation import gettext_lazy as _
+
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 
 class DjangoSeoToolbar(CMSToolbar):


### PR DESCRIPTION
DjangoCMS 3.11, Django 4.1 throws an error because `ugettext_lazy` was deprecated years ago, then removed in Django 4.