### PR TITLE
Have the test-client follow redirects

### DIFF
--- a/django_check_seo/views.py
+++ b/django_check_seo/views.py
@@ -21,7 +21,7 @@ class IndexView(generic.base.TemplateView):
 
         client = Client()
         page = self.request.GET.get("page")
-        response = client.get(page)
+        response = client.get(page, follow=True)
 
         soup = BeautifulSoup(response.content, features="lxml")
 


### PR DESCRIPTION
On the production machine, we have `SECURE_SSL_REDIRECT = True`, and as a result, the test client redirects by default:

```python
from django.test import Client
client = Client()
resp = client.get('/fr/')
print(resp) 
<HttpResponsePermanentRedirect status_code=301, "text/html; charset=utf-8", url="https://testserver/fr/">
```

As a result, `response.content` is empty and BeautifulSoup chokes, resulting in a error 500 down the line.

With this patch, the test client follows redirects and as a result, we get html to feed to BeautifulSoup.

